### PR TITLE
Unity Version Upgrade

### DIFF
--- a/Assets/Plugins/UniRx/Examples/Sample01_ObservableWWW.cs.meta
+++ b/Assets/Plugins/UniRx/Examples/Sample01_ObservableWWW.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bf3770fc51ac89f45987dbde37ae81bd
+guid: ab090c4fc7a564c1d9c69271ac571469
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Examples/Sample02_ObservableTriggers.cs.meta
+++ b/Assets/Plugins/UniRx/Examples/Sample02_ObservableTriggers.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: cb5e978d683e94f4d9c2c81be80f93a7
+guid: 89199274c9e4449399881912f2eacf6d
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Examples/Sample03_GameObjectAsObservable.cs.meta
+++ b/Assets/Plugins/UniRx/Examples/Sample03_GameObjectAsObservable.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 005e349e5ccdd2b47bddc813b81afe40
+guid: 18ecba6a96c174c1f9a87f82eff3e752
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Examples/Sample04_ConvertFromUnityCallback.cs.meta
+++ b/Assets/Plugins/UniRx/Examples/Sample04_ConvertFromUnityCallback.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 73e69fd4bbb724045a4e06050fbc5af3
+guid: 58fdebcd4687d424fb32439432d19a31
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Examples/Sample05_ConvertFromCoroutine.cs.meta
+++ b/Assets/Plugins/UniRx/Examples/Sample05_ConvertFromCoroutine.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 41f3df73f7da66b4980f6d9a86927796
+guid: 2b8c9ff9dffba45a8b54beff7ae10ab5
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Examples/Sample06_ConvertToCoroutine.cs.meta
+++ b/Assets/Plugins/UniRx/Examples/Sample06_ConvertToCoroutine.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5da8247fbc4a4c84e96a727b44903214
+guid: 1fec27262ef3449d2a54429c51ba4a28
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Examples/Sample07_OrchestratIEnumerator.cs.meta
+++ b/Assets/Plugins/UniRx/Examples/Sample07_OrchestratIEnumerator.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d437607dfffa8ff428bda3366354078d
+guid: 5079965a4c2594c01966b7ae720d0eb1
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Examples/Sample08_DetectDoubleClick.cs.meta
+++ b/Assets/Plugins/UniRx/Examples/Sample08_DetectDoubleClick.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: eb801bbfb1ffcd64389e90c8f2435b79
+guid: 76f7c2dac9ecf4c5cb75bd9db9c4579b
 timeCreated: 1455373902
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Examples/Sample09_EventHandling.cs.meta
+++ b/Assets/Plugins/UniRx/Examples/Sample09_EventHandling.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 95140e49213aa6f49a470a81873b87c0
+guid: df98fd6c509bb42a08da54185250b7b0
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Examples/Sample10_MainThreadDispatcher.cs.meta
+++ b/Assets/Plugins/UniRx/Examples/Sample10_MainThreadDispatcher.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6a0b959735346af48b772254afc8afdd
+guid: 6d1d03a37077946cb9a72f2b6b2b8bc5
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Examples/Sample11_Logger.cs.meta
+++ b/Assets/Plugins/UniRx/Examples/Sample11_Logger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f5aa72c61e2548a4bac4d65f93c63bf1
+guid: 315711b9724814fea8aca51cfa44abc0
 timeCreated: 1455373902
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Examples/Sample12Scene.unity.meta
+++ b/Assets/Plugins/UniRx/Examples/Sample12Scene.unity.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4a4aea8df1ad11c47a1db84432dd30f8
+guid: f205c9964003344f1baaf643fa54a7a1
 timeCreated: 1455373896
 licenseType: Pro
 DefaultImporter:

--- a/Assets/Plugins/UniRx/Examples/Sample12_ReactiveProperty.cs.meta
+++ b/Assets/Plugins/UniRx/Examples/Sample12_ReactiveProperty.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 18e34490a83a27e44adf93dd4ffd1f22
+guid: c694760b57ea648579be52076febda2f
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Examples/Sample13Scene.unity.meta
+++ b/Assets/Plugins/UniRx/Examples/Sample13Scene.unity.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b879645f640b02b43a8e78e210c1da1f
+guid: 55f64abd5c4684a7ca91fe4d24699bf2
 timeCreated: 1455373896
 licenseType: Pro
 DefaultImporter:

--- a/Assets/Plugins/UniRx/Examples/Sample13_ToDoApp.cs.meta
+++ b/Assets/Plugins/UniRx/Examples/Sample13_ToDoApp.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 022ecfa555367154c8cf87d61465f7e2
+guid: 2b577208bbce349138a4b29f1ef9e6c5
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Examples/UniRx.Examples.asmdef.meta
+++ b/Assets/Plugins/UniRx/Examples/UniRx.Examples.asmdef.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 71799519d12379b49b6b53aea974bea5
+guid: be50998f2e1254e519953ffe22a574b1
 AssemblyDefinitionImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Plugins/UniRx/Scripts/Asynchronous/WebRequestExtensions.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Asynchronous/WebRequestExtensions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 457f0007b2c70e34e9929ec8f0e2c4e6
+guid: 673fa1e4667814e8eaf113031769191d
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Disposables/BooleanDisposable.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Disposables/BooleanDisposable.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4ff95c6eb380ca248984d8c27c1244d0
+guid: cd4436d5f1a6f47f181d1e5292e4bd89
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Disposables/CancellationDisposable.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Disposables/CancellationDisposable.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6c675907554bfa24d8bd411f386e410d
+guid: 4a82cc6ad6b044f8f8adf340caf9e924
 timeCreated: 1475137543
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Disposables/CompositeDisposable.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Disposables/CompositeDisposable.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a0f9d923bd5f4cd47b39bdd83125de27
+guid: ee9a2d04adbfd47ad9d36489b66bf667
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Disposables/DictionaryDisposable.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Disposables/DictionaryDisposable.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 702939929fc84d544b12076b76aa73b5
+guid: 4b65b1be8d54a4a578ea8d914156c237
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Disposables/Disposable.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Disposables/Disposable.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 958f291bb8f434740a6d2c08ad5182a0
+guid: 79e607375a4f247c6b6d0306dc622d65
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Disposables/DisposableExtensions.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Disposables/DisposableExtensions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9c4757265ae105441bae71007cbd0184
+guid: fd99dc7d1aecd4c4f849c178bb605b46
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Disposables/ICancelable.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Disposables/ICancelable.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b5cd5b0b304c78345a49757b1f6f8ba8
+guid: f6bff7e7d7c2e489bb6a8881ace48fcf
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Disposables/MultipleAssignmentDisposable.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Disposables/MultipleAssignmentDisposable.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bb959083576ace749afd55c1e54b02d9
+guid: f5518ea8a00fc4469ae4e83d404b4489
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Disposables/RefCountDisposable.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Disposables/RefCountDisposable.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2fb5a2cdb138579498eb20d8b7818ad8
+guid: 765eff0dca052449294445cdb3513abf
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Disposables/ScheduledDisposable.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Disposables/ScheduledDisposable.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: db98ce742e859bd4e81db434c3ca3663
+guid: baf98180136814602b15b205f6e11567
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Disposables/SerialDisposable.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Disposables/SerialDisposable.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 06fb064ad9e4d354ab15ff89f6343243
+guid: 21109fd88ce0445769a183c6389d6621
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Disposables/SingleAssignmentDisposable.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Disposables/SingleAssignmentDisposable.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7ec869f7548c62748ad57a5c86b2f6ba
+guid: 85519d9c2e8d543168f637084ada95e2
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Disposables/StableCompositeDisposable.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Disposables/StableCompositeDisposable.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 3a9cd9fa22bc6a5439484581f5049cf8
+guid: b7aa1438063b4462386690a93596a5ef
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/EventPattern.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/EventPattern.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e4b797bfea1999a499309068b7d7a97e
+guid: 2092ef5e989ac4f48863fb9c9cf9ec43
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/InternalUtil/AscynLock.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/InternalUtil/AscynLock.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 23dbd656cfe9c5e47b02c3c263e476aa
+guid: a3e96148d95394e7bae5bf78e4713563
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/InternalUtil/CancellableTaskCompletionSource.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/InternalUtil/CancellableTaskCompletionSource.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 622c7ba8630c25b4c911cd1612ee0887
+guid: 9fda92e3e95c8465ab301fbc623bc86c
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniRx/Scripts/InternalUtil/ExceptionExtensions.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/InternalUtil/ExceptionExtensions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 94d5d10805124b34c8b488ebf3f893eb
+guid: 88f607128d0b74f72b8556bb49ec46d7
 timeCreated: 1509016318
 licenseType: Free
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/InternalUtil/ImmutableList.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/InternalUtil/ImmutableList.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: dbafd8a41f556ec40b4bbd46fca2e85c
+guid: 5b35c69109598461b84de61114c2d692
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/InternalUtil/ListObserver.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/InternalUtil/ListObserver.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 889dc2f3c5f44d24a98a2c25510b4346
+guid: 05d096f401c474b1caffa3d92ea5d0fe
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/InternalUtil/MicroCoroutine.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/InternalUtil/MicroCoroutine.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 108be6d634275c94a95eeb2a39de0792
+guid: fb4693be1d381486199158167ea64499
 timeCreated: 1462599042
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/InternalUtil/PriorityQueue.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/InternalUtil/PriorityQueue.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7956b408e24dc5a4884fe4f5a3d7c858
+guid: 4fcfdbbf7eeb546938bccf22730644ef
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/InternalUtil/PromiseHelper.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/InternalUtil/PromiseHelper.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: daa7aa90cece0fe40920a35e79f526dd
+guid: 2afd052b6ec17494f824a6eac90817ff
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniRx/Scripts/InternalUtil/ScheduledItem.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/InternalUtil/ScheduledItem.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 45457ee4a77967347828238b7a52b851
+guid: 375af01036ae24115873a2af41d70a0f
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/InternalUtil/ThreadSafeQueueWorker.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/InternalUtil/ThreadSafeQueueWorker.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 768cbfcbe2a8e704a8953eea28cd33df
+guid: 9dd27483dd21c4588af1c8225a14eabd
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/InternalUtil/UnityEqualityComparer.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/InternalUtil/UnityEqualityComparer.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 626a410137515ac45bb59d1ca91d8f3f
+guid: db0a91dc3aaac4d71a9179999ebf96f9
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniRx/Scripts/Notification.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Notification.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 169d02559aa6b3e459fbae10f2acecd8
+guid: 8f33bdeb31ab44fe3a1a482b8f8ea1c4
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Notifiers/BooleanNotifier.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Notifiers/BooleanNotifier.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5ee30c0abdddd7241acbe24df0637678
+guid: d2e949bde4b4f42ce80b3186354cd5e5
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Notifiers/CountNotifier.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Notifiers/CountNotifier.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 503af1c1dc279164e83011be5110633e
+guid: 0d68260dde68b409fb7c97b3cc485d32
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Notifiers/MessageBroker.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Notifiers/MessageBroker.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9dc5e3c48d083d4418ab67287f050267
+guid: ba6a0ae2b5e544bb89243134233da282
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Notifiers/ScheduledNotifier.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Notifiers/ScheduledNotifier.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e6f53242e655cbe4e889538216dc9e17
+guid: 5841578e7c56f4bd1b300cca3ba41736
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Observable.Aggregate.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Observable.Aggregate.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 82339dddb2a9f944785f1555b83d667c
+guid: 171e7c6c6885d4b6f96ed48a5e572a22
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Observable.Awaiter.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Observable.Awaiter.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ec3ea3f22d061964c8f06eb9ea78ec42
+guid: 8b0d674a0a9ee479d8a7929a2c8f6d29
 timeCreated: 1475137543
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Observable.Binding.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Observable.Binding.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bb11a562e64264645b76ad3a8d15d966
+guid: 9f97da09b1eff4afab6e889544d83837
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Observable.Blocking.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Observable.Blocking.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4a05ec8aabbdba24388b7b2ae6c4a474
+guid: 5933ffde95b3c4068bb32cbeb3dffcfa
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Observable.Concatenate.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Observable.Concatenate.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 18c56bbfaaeedf445874f4246d42b509
+guid: a134ca91331e84409ae010980f7595df
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Observable.Concurrency.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Observable.Concurrency.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a31d38ad13dc4644180647afc28c6045
+guid: 15973a91a25564fdd8b2d507c6a569ae
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Observable.Conversions.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Observable.Conversions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e32bd7bbf28014b4ab2873cc8de3dea9
+guid: 50258b626a4144acea2a7591de1198cb
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Observable.Creation.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Observable.Creation.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e63036d2dba75f64382beed512fd086c
+guid: af6f703a4f84748b28eecb5fa1a62915
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Observable.ErrorHandling.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Observable.ErrorHandling.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f40cab35efe24e6448ac8455bc7a4eb9
+guid: a1ae76f346e5e4052b41d02358722507
 timeCreated: 1455373902
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Observable.Events.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Observable.Events.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e591aafff0492c94590cf9702f6c408f
+guid: e9a54d18a35044534985a1c175390ec1
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Observable.FromAsync.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Observable.FromAsync.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 601f5bb7bb302a14cb46df717729b8c7
+guid: e8ca0f36d5347438a95dabc27e8a2493
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Observable.Joins.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Observable.Joins.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: dd92425c6c6dec24e9e52677cbc36aa0
+guid: 0dac029d3f3c244cb8514dd142c07a93
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Observable.Paging.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Observable.Paging.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f4c9428bf00006d408fcfe4c514ee798
+guid: 64a4ff7faf86141079d85860e48911af
 timeCreated: 1455373902
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Observable.Time.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Observable.Time.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7da89fcf95f5c364ca62bbb874005d32
+guid: b088615069af84872a0f0e3d9878f0e7
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Observable.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Observable.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a2dd1c80d4559fd4ca9ef62f20d031ab
+guid: 8db5d9a19a8784c53accf678799dea44
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Observer.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Observer.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 57d25c3f6fa1d334e89c384393252b8a
+guid: 2e0eef202a07647c99acecbe5cfc5c53
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Aggregate.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Aggregate.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f777fc54ecf275349a3f007e760705b3
+guid: 0348778fed05b42eb91807c47104a742
 timeCreated: 1455373902
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Amb.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Amb.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ad1a22922a735ee479baf0e179648532
+guid: c92133d485998401d8f0e5820c178aaa
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/AsObservable.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/AsObservable.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9e4851fd48b2b42469d71b311254877b
+guid: 9e06d3452b8ae4e57a288c1a10555c1b
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/AsSingleUnitObservable.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/AsSingleUnitObservable.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 3b5e05dba2d3aca4e9c3a6312bef8690
+guid: 282356083e949481bb668cad63acb08a
 timeCreated: 1462636004
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/AsUnitObservable.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/AsUnitObservable.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 236f5f407bf92c949844fcaf450af450
+guid: 1eda871a45fbc4dde9b54a45b13dc9ab
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Buffer.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Buffer.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4137aec9640d3ea41a740d677026aa8c
+guid: eda79f1139d3e47dc99494c006bc54e7
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Cast.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Cast.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e70ae559c9b927742acbff91d50b3b22
+guid: 847c646cd32db463d9a5844f6c0c1fe7
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Catch.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Catch.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 404a684db151ca34f8258c6fb373db8d
+guid: 63e76ffde0384431782b7d01a70347fe
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/CombineLatest.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/CombineLatest.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 64910ffa78510ee48b3a395ee5b2cfe1
+guid: 5c9e87a45c3ac4feb89ec4bc340a575b
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Concat.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Concat.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 740c2691a7e434f439abfdcac75ea809
+guid: 8b57b69a3288f49d9af3771b91b1ae2b
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/ContinueWith.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/ContinueWith.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bea59b3eb246d244a99183eeb7f3bad4
+guid: d27126dde4cd241fe9a537007da7316a
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Create.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Create.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: cae9e62bf5eb3dc4e9d93cf6ff606052
+guid: 9df6c35a69e8c4bb3a4a2c14b4c81408
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/DefaultIfEmpty.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/DefaultIfEmpty.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 551075cda284fbc489824d153743b1e6
+guid: 3a3dd1106306a4a83ac5603161adcb23
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Defer.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Defer.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 15ca418b98836d943864b1e8b82f6658
+guid: f519946efc65c4c459f2e142a095a54f
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Delay.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Delay.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2af9c507ce062994a904e4b5565b49c0
+guid: 7779acc020a3c4ae0a1ad1dcdc8e372d
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/DelaySubscription.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/DelaySubscription.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4f532fc776d5298439cb8f03d52e1211
+guid: bfe85b396b9d74700b93045e39359ee4
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Dematerialize.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Dematerialize.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 80682be7e41afb44581208534f226d38
+guid: da15fec0db2c94b2bafa2a6ed39a6548
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Distinct.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Distinct.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 376a7ed430bff5c4b860af4d23ab6b79
+guid: 47ad16fc1dc534601b5d37bd8bddccd8
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/DistinctUntilChanged.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/DistinctUntilChanged.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a09c4b58f60c22342871c30eaf589f6c
+guid: 2e4ef9c26245f4204ba877b5b5fa878f
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Do.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Do.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8f99ae8870195e34b8618451a95818e0
+guid: 68e2913821ee14b2796daf1c427f5b35
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Empty.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Empty.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9e9a7050a289d3a4aa17cba89e085135
+guid: d4624f0715fd240a5913c2245436f06c
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Finally.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Finally.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9ce919d8f2acf2b47a932e850e399d3a
+guid: a3a90e74d9331488f9b2c076c46beef3
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/First.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/First.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8e3093220aeb1d54faa3fca9fe0af6c0
+guid: 0fba2ef69eec349feb191ea7373516e1
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/ForEachAsync.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/ForEachAsync.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5b66ecd2e5290bc4eb8c78a1ccc2d009
+guid: f2b9ee9563cd3474bb9833e4dbb223fe
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/FromEvent.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/FromEvent.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 05fcc5083e94e704ca8f059e4e535ffa
+guid: e3db41d869aab4eb28109b4a706c9a61
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/GroupBy.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/GroupBy.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7345fc4a6df05ca47ab89ec819bccde6
+guid: fef60551e855f4aa68678e0517a2c2fd
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/IgnoreElements.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/IgnoreElements.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d6c8ca210619da74b92cbdb3e8c58127
+guid: 04303f479a5684099908b937b00897cc
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Last.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Last.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 696780c8759162d4b996683ec13d7e0b
+guid: 83d6fafb3dff642088f4baafd90c380d
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Materialize.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Materialize.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 09d3ba9e6d5fe4643bbf0df943652908
+guid: 291d939a4cd364a26b0ef03ed25fcd04
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Merge.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Merge.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 94158fab525468d4e896a62f633257e6
+guid: ebfd2a399eb0a4b15bb65d469b1e8e8f
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Never.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Never.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b5db8d5c73883214abaf3715002da256
+guid: 98d87b86b79fd434bab89a879685a038
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/ObserveOn.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/ObserveOn.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 39df784f492c7404286d05b09a840705
+guid: dffb2e1fb32aa471c9b69db3a0d99e47
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/OfType.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/OfType.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 981fd4bf7704404459a0deed254a03e5
+guid: a4c951a9d55cb40ee9b0cec75f9c42be
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/OperatorObservableBase.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/OperatorObservableBase.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1b94a1a0ae5d509488c6242454216bdb
+guid: 4d41689ac4053413788560517c439bd8
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/OperatorObserverBase.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/OperatorObserverBase.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 258901a4513be8f4a8bfcca91e70bb12
+guid: 5d03e005f68af4cba9842d1d72773ffd
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/PairWise.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/PairWise.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f66e4871304e6e74d8548d597457e53c
+guid: 1060160a5d6a34380966cfd709486707
 timeCreated: 1455373902
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Range.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Range.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2249fbe589c8d3042ac201c1ab4be76f
+guid: ea43082b443db4ae986beecfa727563b
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/RefCount.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/RefCount.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 17a77b422aa699d4d8cfbf6de804d238
+guid: 37206f15de4f248289f0fbcbdf98f519
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Repeat.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Repeat.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 63930706f2ea6e847866fc6d914b0d2e
+guid: f8ecd0ff7b0df41b7972b6f7e166da95
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/RepeatSafe.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/RepeatSafe.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6458fa5124443dc4bb95ad3d0b743934
+guid: 7b97485052f4a4335b9b5e5cbd26d44a
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Return.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Return.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 25648117feeec6043bd39468bfab62b7
+guid: c0a5f430343ba4cedbce45e389c57103
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Sample.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Sample.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 414e918f6a4dfc549b2a8c916a6325e1
+guid: 1128f4707b7634c4e83b19c82df8306a
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Scan.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Scan.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 461fecd0ef4d48c4d95aae68c2ca2c1c
+guid: 1ef91f7c65c684e27ae61706b7117772
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Select.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Select.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 997e36ad7b02b804ea1f03d05e60bed5
+guid: 37e96cd279a614dd3a24e19c5798146e
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/SelectMany.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/SelectMany.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6496e8557f6066e4380c32935b6f37c3
+guid: 24db6c8528ab943a499a5abede53dce1
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/SelectWhere.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/SelectWhere.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6a7561d10967d6b4d9c2a67ffc3b9d85
+guid: daef8a707b8ae448ca90ee27f69f0106
 timeCreated: 1468748731
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Single.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Single.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9a50aee929f403f4ea076fc11f71fc53
+guid: b7f3cd309c71f4cec925b0292706696e
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Skip.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Skip.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1ffcb45c02e14e94bb37c6513b04bb7c
+guid: c7ab02d439bfc4d66983691ffb1651b4
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/SkipUntil.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/SkipUntil.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 52314487e375f3d44a49bc5ceb90adab
+guid: c86139391000c4191b639d514b1a7c4a
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/SkipWhile.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/SkipWhile.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4bc7a1e818d05654694d51e883739cca
+guid: d35b7b5a7002841e6b63e1d80326b2bb
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Start.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Start.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2b99cac67f8c387439619e01a480c465
+guid: a0d2e50eef52a4033b982b4b46585313
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/StartWith.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/StartWith.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 05df6719453543e458dc3e0d29ac7fa8
+guid: 5befdcd46377d46bc90731c21a24d003
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/SubscribeOn.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/SubscribeOn.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bff34f363b1797c4396815b5b3a4be1c
+guid: d26dcc2cb51674a61ad33e6bb842cc6e
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Switch.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Switch.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5e16cdc638ec3bf41bbd380b75991734
+guid: 3b9dd44d451e14aeda03993f35d142b7
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Synchronize.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Synchronize.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 31ddcb8477b384b4c9867568f6dc8359
+guid: dedeca8f29a7d479da19b393f6a5860b
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/SynchronizedObserver.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/SynchronizedObserver.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4fd465af6ee05a64f9115b45b58360b7
+guid: f829ea59753e34a5bad109f7485004d3
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Take.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Take.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5275fc8bb6611984781d8ccd56b9b572
+guid: af859935f98044e059eac093e4aceff8
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/TakeLast.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/TakeLast.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8ea2ac59577a3214f9fb66ccc62f2ffd
+guid: 03bee4b094499405582c0db36ce1a4a9
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/TakeUntil.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/TakeUntil.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 163e3eab299b735418c94e634fecd811
+guid: 57ea7f0825dc14f38b636548669bc97a
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/TakeWhile.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/TakeWhile.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d6f2da76023d9734ebb4ed1883fda2bc
+guid: 2a92998d377e248b6abb9a7fdb44f606
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Throttle.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Throttle.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: dc296a61927394b4b908b385087f23d0
+guid: 096de9778c57d4a08b174bfc5e5a8d4e
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/ThrottleFirst.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/ThrottleFirst.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 32b6a6efbab897b41a055d830a4d9755
+guid: 6aaaf2169a7ce48ac98c82dceafd6bef
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Throw.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Throw.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1e5623719e9b1f1418aa67a63abed4cc
+guid: 15cc0a828f6df41549ec936aedea3d0f
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/TimeInterval.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/TimeInterval.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 065e40ebd4bd4a848b58a7a90dac881d
+guid: 7611da6da18994755b07179effe29d11
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Timeout.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Timeout.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a22cd4a86f62fc64384dddb043530703
+guid: c8ad941246f804a25aa07e81d63b3d9f
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Timer.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Timer.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6be220be1da39e14ea87b366c149953e
+guid: b320be16484a54c8b8405415f572e9ca
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Timestamp.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Timestamp.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d9ec806fec477b243a812e7f609a4453
+guid: 0e97a7326149e44c8ae3d0eaa2006368
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/ToArray.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/ToArray.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 38d1f7c869353b542af469b0e3fae89a
+guid: 6471c5b4fdb0647048bfa6d44f4d9023
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/ToList.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/ToList.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: cee1b9300a644c9458346c1f80f64197
+guid: 69af3c6ca64cc4bba8f8bf5eaa6ef9e8
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/ToObservable.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/ToObservable.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7cd3ae084c8ca754f9aceca2e18c3af9
+guid: 01cf1d48e74754fd5a9cf320e0006570
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Wait.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Wait.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ea55c5647aa075b4f894dd37abf5e469
+guid: b3327aa50e5db4068ac8c17b5df861fc
 timeCreated: 1455373902
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/WhenAll.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/WhenAll.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 0af8ada83db8f8a408ee6e9aa994fbbd
+guid: 547339c95d16f49bfbb5d502464146c2
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Where.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Where.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a035699dbe9572548afa47c460bad078
+guid: df9c7c8eb38024542803cd74ae44b5ac
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/WhereSelect.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/WhereSelect.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f7453a184d42aa34c854977496f381b9
+guid: decf1dd6f46d5497b986073c33eb1c73
 timeCreated: 1468743755
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/WithLatestFrom.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/WithLatestFrom.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: eb0bc7125d343ed45bb7e36ff1a53362
+guid: 9a41ca54ea55745519fe4097312ab30c
 timeCreated: 1455373902
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/Zip.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/Zip.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4e92e25f9bb221d478d4af5bcd8b8a2c
+guid: dc5073d2f8e1f40b8b7ca17684da1561
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Operators/ZipLatest.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Operators/ZipLatest.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f84ea50040d682c43811d1d98ae7fec8
+guid: 668f9ae84c7994d9ba723f391b57c8d2
 timeCreated: 1455373908
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Pair.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Pair.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7947c520dfd9de94bb381e45dc105752
+guid: 62aa0a1a975ca4cadb5dfdb52a8c1185
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Schedulers/CurrentThreadScheduler.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Schedulers/CurrentThreadScheduler.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1d547b5ee71b7284db1fecfcdfa59fac
+guid: db04704c2718e4546991eed516148b06
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Schedulers/IScheduler.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Schedulers/IScheduler.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7409b202c20d3894b9677c8f2a27f3aa
+guid: cd018873e347248d2901adcbeaa93838
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Schedulers/ImmediateScheduler.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Schedulers/ImmediateScheduler.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 87be5fca34f9b44428b7fb1ce9147860
+guid: aa256f58d7e104de49237908625e7e95
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Schedulers/Scheduler.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Schedulers/Scheduler.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bfeb53a7ea29f714798ba6bb3bd70ba4
+guid: b5769d9f226114ecbb087426bf332461
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Schedulers/ThreadPoolScheduler.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Schedulers/ThreadPoolScheduler.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f8189a60f4619be489df10eca6a78fbb
+guid: 91454a251e308498eb41f7f61472e7a0
 timeCreated: 1455373902
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Subjects/AsyncSubject.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Subjects/AsyncSubject.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 137cd44250b484d4ba2390d510f8423f
+guid: 312239698a6a848ac8c0527ac4b65c24
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Subjects/BehaviorSubject.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Subjects/BehaviorSubject.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2fa461d2fc0c4ec4999e0b9aff16dd47
+guid: a1110459c6dae4583a748768cfdc8cb1
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Subjects/ConnectableObservable.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Subjects/ConnectableObservable.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8de419b467eded246bc4fc5e70859f73
+guid: b23ca2bb3f18a455d9d0804a023d2bb7
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Subjects/ISubject.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Subjects/ISubject.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e9dbcd28e4f3965408744e0ee03b7bc8
+guid: 6006aad7aa93741cdb67756fb62546c9
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Subjects/ReplaySubject.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Subjects/ReplaySubject.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d9b0c2f29645e1f468259893bf9afb68
+guid: e6e7aef11c2b44c0d89a21b18feb59c3
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Subjects/Subject.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Subjects/Subject.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d5fdc90caca9cbe4b9cd9c3fae81e7f6
+guid: ba90037fe805e47b38589212cd7b0d1f
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Subjects/SubjectExtensions.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Subjects/SubjectExtensions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 359bf19588606a14fb0edc6efa97deaf
+guid: f98980b93474d47de92b53850a62581a
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/System/IObservable.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/System/IObservable.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9703f7aad3c6b334badd37c1b41d0d8f
+guid: 1b8bbc6ca99ab403bbba2c268f97bd76
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/System/IObserver.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/System/IObserver.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1fc7a9cec9d3b644da7dbcf18ea16270
+guid: fa52f6759c1c142bb908b0e663f4c8d3
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/System/IOptimizedObservable.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/System/IOptimizedObservable.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5a2d3a7c73260e14a875d62586ae28f9
+guid: 3fd3933981c004793bbdb48e6f16de86
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/System/IProgress.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/System/IProgress.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a38a024b6babf8d48b7e32f2f8fb8686
+guid: 4e0d6c03fc9a4431f859426e7f72bac0
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/System/Tuple.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/System/Tuple.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: be811500a5640704b92de622c9202d48
+guid: 4e2a3b5bd19ef43388875ac53bdf3dfb
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/System/Unit.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/System/Unit.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 14f6907c0ae17e64c8fc34f08c3038a4
+guid: 3d4ae34569049405b912c2b60c6c1e0b
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Tasks/TaskObservableExtensions.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Tasks/TaskObservableExtensions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d4f80d45cec56574e990cc840d1ac16b
+guid: 343eaafc5b8d04993975c3e3a5879804
 timeCreated: 1475139656
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/TimeInterval.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/TimeInterval.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: dd48622e783cadc47af9a6b456ac8438
+guid: 6ad17f95b83e14ce687cc0bbc1f55c97
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/Timestamped.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Timestamped.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c1d908b82d0e2b4489d3351a484e5eae
+guid: e3d9580e60efe45ef959e737edd0432c
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UniRx.asmdef.meta
+++ b/Assets/Plugins/UniRx/Scripts/UniRx.asmdef.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 560b04d1a97f54a4e82edc0cbbb69285
+guid: 9115d85c1fafd41b8ba32ea9f2434cc8
 AssemblyDefinitionImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/AsyncOperationExtensions.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/AsyncOperationExtensions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 245d77a29b1ece34e96bfc80f8c825d8
+guid: a0fddfb8a057242ffb90f08cb42bee83
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/CancellationToken.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/CancellationToken.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e02a1bf45f8861048a6014cf7eab1825
+guid: 432a037217bba42b9907d8e82991205b
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/CoroutineAsyncBridge.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/CoroutineAsyncBridge.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 93ca3de3810199947871ab4a77014fa3
+guid: 4cc7163ceaa1b4d40b4a5bab6179c26e
 timeCreated: 1475193276
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Diagnostics/LogEntry.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Diagnostics/LogEntry.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 53917e87e91c0e4449402e5d85a04765
+guid: 71a2497195e26495ab61afa4e90424cb
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Diagnostics/LogEntryExtensions.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Diagnostics/LogEntryExtensions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8706ef5a13e53ec46b4848a7eec5e826
+guid: 52929bbd7c82349278508cc2a4573bb3
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Diagnostics/Logger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Diagnostics/Logger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f0ecf366503cb0644bdd90934d24da62
+guid: 67a73a2a998df45c2aa922bbdacd78cf
 timeCreated: 1455373902
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Diagnostics/ObservableDebugExtensions.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Diagnostics/ObservableDebugExtensions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b43f948e095c3e749a0506709be90d68
+guid: 472c887ffc5b64c9c80d28dc08617094
 timeCreated: 1468662620
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Diagnostics/ObservableLogger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Diagnostics/ObservableLogger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 063f79dc45f902c459f0955d27b445d7
+guid: 148f197af86db48b0ada654dd52326e0
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Diagnostics/UnityDebugSink.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Diagnostics/UnityDebugSink.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 882166c30c3bff841b1e12d62c392e02
+guid: e79607593e1cc4a52a81c6bf4e54b977
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/FrameInterval.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/FrameInterval.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 266d1e44d71e7774c9abc5b23773e3f1
+guid: 4ca559170d31c4a0eb648857331b001d
 timeCreated: 1467771656
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/InspectableReactiveProperty.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/InspectableReactiveProperty.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 13c690f353ea23141aca4090d28aaa9c
+guid: 2a34a44e5011d4e3195a3d0f411eb152
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/InspectorDisplayDrawer.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/InspectorDisplayDrawer.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6180f9fd2198dee44ae7f4a617529ffa
+guid: 55d1a86b093964894850da1bfc1c751e
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/LifetimeDisposableExtensions.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/LifetimeDisposableExtensions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a7474e4acdc541340a1f566b2df46355
+guid: 1bb7d13abb71d4c83a2c322cd651c85a
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadDispatcher.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadDispatcher.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c3cd207057515c4438a31a6a7b548fe7
+guid: 7d04aabe321754b6b9d01c9dfe7ad7a1
 timeCreated: 1465903910
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadScheduler.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadScheduler.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f141c5dc72b97084a85631367a946ee8
+guid: 336225a4c813a42e2b1544e2b4e9f192
 timeCreated: 1455373902
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Observable.Unity.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Observable.Unity.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c6ef0a186b9ceaf41af7f2a9f4006216
+guid: f8e1babc3697d434eb9afd809f4637b7
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ObservableWWW.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ObservableWWW.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ba71e5544e233dd4b83d4c5a6c696d05
+guid: f85e03a814ad54688ba21a0fc1b257b9
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ObserveExtensions.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ObserveExtensions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8741793924a6c2f4ea22ba27031d531f
+guid: 76622ed273e3948f484e3b01eff088fc
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Operators/BatchFrame.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Operators/BatchFrame.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 74a2b6b8c63d1144f914c7f0d6719a36
+guid: 13373e3d44b544d13a1249f8ac4a2e50
 timeCreated: 1467771656
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Operators/DelayFrame.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Operators/DelayFrame.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 868f75a703f1a944a801ab9c9b4512aa
+guid: 0f62e7d3b0321496595a050876fa99f4
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Operators/DelayFrameSubscription.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Operators/DelayFrameSubscription.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ecfef95eedf36c2448944fb8932f682c
+guid: bf2032fefbb9c49bda769e2ec366af3e
 timeCreated: 1455373902
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Operators/FrameInterval.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Operators/FrameInterval.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a731a1a74be20a04a9d7dedc5ceefab2
+guid: 1e675971114b34d2a82c413f73cdd7f6
 timeCreated: 1467771656
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Operators/FrameTimeInterval.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Operators/FrameTimeInterval.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a55cce9ef638364409d1227a25a32421
+guid: a4fd2c6d55b164fb59cb34b9298998df
 timeCreated: 1467771656
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Operators/FromCoroutine.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Operators/FromCoroutine.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e83ddad992535fb4f8a68a1e7ef8be60
+guid: 6c35c0194e6cf4405a5aaa03873fd07a
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Operators/RepeatUntil.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Operators/RepeatUntil.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 93507e8a72a71094f870c8dbe1e5bed8
+guid: 382509feef6f94da48f571d88bc885cc
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Operators/SampleFrame.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Operators/SampleFrame.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e04c7fc1929a3db458bf7ae31bcd9e55
+guid: 43fe99ce39ed94e4094ac518f4810da0
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Operators/SubscribeOnMainThread.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Operators/SubscribeOnMainThread.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: da3fd97518766ab43827991b7b5d4270
+guid: c705ca3f2d7814448b0dbf37a44bbdc6
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Operators/ThrottleFirstFrame.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Operators/ThrottleFirstFrame.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 3ec92e777b0b4d949967b0663ce8bee8
+guid: 674416b13f9344471b856ce97b742699
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Operators/ThrottleFrame.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Operators/ThrottleFrame.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2c4ef0bfcfe787543999c7a6cda03c07
+guid: 0897cba5f8e90486bacdd9e57032ffd6
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Operators/TimeoutFrame.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Operators/TimeoutFrame.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c27be0a585d78a944bccd31b86ee6722
+guid: f0932e3b01f69474fa4b4e4c98bb6cfb
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ReactiveCollection.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ReactiveCollection.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2e22185fb1dbcef42bc613efd4769011
+guid: b9eee0d5461614700a1e807ebcc746dd
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ReactiveCommand.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ReactiveCommand.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 939b249fde5252f45a4404e7648931ed
+guid: 0b20579ff9ab04855ab239c7a8f9ffc5
 timeCreated: 1462927720
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ReactiveDictionary.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ReactiveDictionary.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 12cd1079b0fe33f429f9f174c1f849af
+guid: 4bceebd41bdcd40acb23bee32caf1005
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ReactiveProperty.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ReactiveProperty.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 88e12aa895fef434fbe3ea0cc8f57301
+guid: c486fcf159cff4f8bb45738398ebae5b
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ScenePlaybackDetector.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ScenePlaybackDetector.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8d380d86e2ef6674c83ca983a1604273
+guid: 95a7a0aa2d598428c9520c66deaf7e95
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Toolkit/ObjectPool.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Toolkit/ObjectPool.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f4980e1e001c7e94fab3250ba284dc91
+guid: a77242ada53c34a52aa29b0e5e90bc5d
 timeCreated: 1468655394
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableAnimatorTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableAnimatorTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e03f9257cc6667f4082439aa77d6f01e
+guid: 72a85f73a3572498cadd263728d75307
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableBeginDragTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableBeginDragTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 3a81a9b6bec6b4f4fba7e0047cd989f6
+guid: 57fa8e30c9afd4f3d922f7e7e0395591
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableCancelTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableCancelTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4c0a9070b7cc23746b2c0e2db3ec16cd
+guid: e21697efb734840acb15ce87fb8857bc
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableCanvasGroupChangedTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableCanvasGroupChangedTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 54095d3e740f7714085d0568207cbfe0
+guid: 1d158e07e7992492d93c229597e2ac0c
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableCollision2DTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableCollision2DTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1be7847b61f30f24daa5762db87a5b19
+guid: 288da8106360748f2b380967964f49dd
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableCollisionTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableCollisionTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 10b917196cbfcf74898ce1686e205d04
+guid: 45ab122ace9a049e7bba3ba78c75cd3c
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableDeselectTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableDeselectTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9fe6f69c4d869c04e8a1924aab1d3694
+guid: 3aea8cc2b2b214324b0b4bd2ab3ea61c
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableDestroyTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableDestroyTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: cb219b23cdf4b314f94a27bca3cc8012
+guid: 2b6e5dd8153214971b23f5670aa2cee8
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableDragTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableDragTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 79db090dc9e4db245821e8b89b0e208e
+guid: e1e5710ef657a440bb4536ccdd2759ea
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableDropTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableDropTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f2ffa8b5af3474446a310bb6aa0b180a
+guid: 44ba307d2dd1449139355f22f3ed412d
 timeCreated: 1455373902
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableEnableTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableEnableTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 0d9c7eb607af1fd4aa0e15f52cc0543b
+guid: bf365be5348b14704ba70ac4f01ce47b
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableEndDragTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableEndDragTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b8ce8424f238d6842bd8b09c0cca1ac4
+guid: 34c2609cc3628415cbdfdbc89e1bbb5b
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableEventTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableEventTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 48e93426b16d5454c89e8d47ccded1c5
+guid: 99fdec5515899424ca701a3826c1ea12
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableFixedUpdateTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableFixedUpdateTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d525c42c11d945f4398061ed8f84e5f4
+guid: 8d9f35819350b4174b42c179af63536f
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableInitializePotentialDragTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableInitializePotentialDragTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 3f3148a9e1b8b21409f54d2b0c2c81de
+guid: 3073a7954b45e4dcc896cd52c05e13d1
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableJointTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableJointTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 79b758631951cbc42b40ea87072e1ab3
+guid: 8cf5807fe7f604df2bf4fafb2da43214
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableLateUpdateTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableLateUpdateTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 176ace24965d0c744bc61c8aad8b3fc7
+guid: 71f3e4472149a49e08a736fdd5ce2d7e
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableMouseTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableMouseTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c5f30958c5509bc4f9c14ea261a1567c
+guid: e1f6c0df42332459abb929d54367a401
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableMoveTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableMoveTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 3e1feec0f10dcea4d9c779a81a0ee3dc
+guid: 1163012e42d4d4ce6ab91a1933593e6c
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableParticleTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableParticleTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9e6a20494274d5045a1b36a770ea76b4
+guid: 056b53316aab34f3db426d93f3d19849
 timeCreated: 1468669952
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservablePointerClickTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservablePointerClickTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: aa69c313aba23f945b760e79c45083ad
+guid: 95537307306c14dffa2fd34db40b5b92
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservablePointerDownTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservablePointerDownTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c7ae5b5965df2344d99ef7792521b937
+guid: 061d9f3c4955b43cbb896b54b9883d3c
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservablePointerEnterTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservablePointerEnterTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 3468b3db8d419c745b12124f6432696b
+guid: 4afc45becc2604c34a5e561ef29489b3
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservablePointerExitTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservablePointerExitTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9643e74593988274bbed9adf40384e48
+guid: 9b124a9cba77e46ffbe16373a0874f29
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservablePointerUpTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservablePointerUpTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 41b0031b2e409894aacafa49d8583617
+guid: 701669d4c38174f6db18785a43bbb519
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableRectTransformTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableRectTransformTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 20b97bcdd98f27346851c3a690ec7faf
+guid: 2798dadd277424ce6b746e28ef7f70c0
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableScrollTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableScrollTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2231ec04e488f7443ae7acf609ac5f00
+guid: 744713e62d5fe417b864aabae21c5554
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableSelectTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableSelectTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1e4cb287d3ab8274885ed05748f26329
+guid: a8c032626d7df4354bb4c3592214f69c
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableStateMachineTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableStateMachineTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1e29959e46c7ea7409560769cde085ae
+guid: 8617c39b266b744ee92f4f71b0e2a6bf
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableSubmitTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableSubmitTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 655296fedabd6004ab699ab9749e369c
+guid: 3e6723e38da3b42fc9755cfe5b7d1198
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTransformChangedTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTransformChangedTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 835e244a602942c4c84a09c9bdedf229
+guid: b330ae8ec0f1d442c9f77bc6dcf218e1
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTrigger2DTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTrigger2DTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1aad3129752ef804999a880a7b2d72ef
+guid: d2f29ff97dc7c42cd816b965f95f469d
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTriggerBase.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTriggerBase.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 850bc951297608e4fb0722795c21ed16
+guid: 6fb2eef27e48c4b2c8a5c4306661ecce
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTriggerExtensions.Component.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTriggerExtensions.Component.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d10150b3ca6f3924baae5bce4343f6c4
+guid: f4aadb4e3f0404296947ca0926ed26dc
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTriggerExtensions.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTriggerExtensions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 3ee4df960144b9042874516111cf2d6c
+guid: 115c648281aec42bea461c80b577b605
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTriggerTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableTriggerTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: cadcfd987fed8a044b75709fc19ad0f7
+guid: 05fa046145eaf402da7d2daeb061b809
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableUpdateSelectedTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableUpdateSelectedTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4d207a04db328fd4d970c1457530deb3
+guid: f41ce31e8de81448f865d312bf23d822
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableUpdateTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableUpdateTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ceb5e5014f40d6948815a7be8b174ff2
+guid: 0b67d07a007a8424fadafe724bdb93a1
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableVisibleTrigger.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Triggers/ObservableVisibleTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 03515121745b2d74c8782ce92eb2a1a0
+guid: 42141c6f59d494befa3bd6c664ff173a
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/UnityEventExtensions.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/UnityEventExtensions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e3c4861cc04ac524484d0730a3a5bd4a
+guid: b51482b169b8441f98d1e9f9be1e2630
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/UnityGraphicExtensions.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/UnityGraphicExtensions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 99be646df339108498ebb70efa1b7bd4
+guid: 1e25e8af7efcf45989d50822c2a82bcf
 timeCreated: 1455373900
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/UnityUIComponentExtensions.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/UnityUIComponentExtensions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7645084659bc779448e384456805d251
+guid: 6286f2c691a324be5b1779949363e2a5
 timeCreated: 1455373899
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/YieldInstructionCache.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/YieldInstructionCache.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2493deaccf35b0542800b0851771e665
+guid: c689e8d4267004703ba131c4b90d338e
 timeCreated: 1455373897
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityWinRTBridge/Thread.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityWinRTBridge/Thread.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bf1175d5dd9b5904d898eb4c9dd7e0c5
+guid: 06e4178e153b945338dc39d7e849275b
 timeCreated: 1455373901
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniRx/Scripts/UnityWinRTBridge/ThreadPoolScheduler_UnityWinRT.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/UnityWinRTBridge/ThreadPoolScheduler_UnityWinRT.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2c36c9256c17bbb40854ef9b9e4d51c7
+guid: 8c2110f2e97624723a52ec02d1a2eb74
 timeCreated: 1455373898
 licenseType: Pro
 MonoImporter:

--- a/Assets/Plugins/UniTask/Editor/SplitterGUILayout.cs.meta
+++ b/Assets/Plugins/UniTask/Editor/SplitterGUILayout.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 40ef2e46f900131419e869398a8d3c9d
+guid: 507d2c16412c14f54baeab7388705d54
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Editor/UniTask.Editor.asmdef.meta
+++ b/Assets/Plugins/UniTask/Editor/UniTask.Editor.asmdef.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4129704b5a1a13841ba16f230bf24a57
+guid: 5462b7c5626c745eea6dd6dcf64408a7
 AssemblyDefinitionImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Plugins/UniTask/Editor/UniTaskTrackerTreeView.cs.meta
+++ b/Assets/Plugins/UniTask/Editor/UniTaskTrackerTreeView.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 52e2d973a2156674e8c1c9433ed031f7
+guid: c41751b2a74964ab5b3eba85577d469a
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Editor/UniTaskTrackerWindow.cs.meta
+++ b/Assets/Plugins/UniTask/Editor/UniTaskTrackerWindow.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5bee3e3860e37484aa3b861bf76d129f
+guid: 4f8c7d0dbce9340f2a24050d241de3ba
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/AsyncUnit.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/AsyncUnit.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4f95ac245430d304bb5128d13b6becc8
+guid: a9dcdcbe1406b403e821c8237d0d109c
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/CancellationTokenEqualityComparer.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/CancellationTokenEqualityComparer.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7d739f510b125b74fa7290ac4335e46e
+guid: 9cfee150887844edeb27c9e879fa7cb0
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/CancellationTokenExtensions.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/CancellationTokenExtensions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4be7209f04146bd45ac5ee775a5f7c26
+guid: ec919877d6c9f4a03a2aa9380fd3e19e
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/CancellationTokenSourceExtensions.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/CancellationTokenSourceExtensions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 22d85d07f1e70ab42a7a4c25bd65e661
+guid: 5b456eb185d9d4ce0af21e317a833b1a
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/CompilerServices/AsyncMethodBuilderAttribute.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/CompilerServices/AsyncMethodBuilderAttribute.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 02ce354d37b10454e8376062f7cbe57a
+guid: fa4dfe98cef75460a8335523b16d8282
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/CompilerServices/AsyncUniTaskMethodBuilder.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/CompilerServices/AsyncUniTaskMethodBuilder.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 68d72a45afdec574ebc26e7de2c38330
+guid: 4d4e807f3c16444f1800c4890019b7e0
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/CompilerServices/AsyncUniTaskVoidMethodBuilder.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/CompilerServices/AsyncUniTaskVoidMethodBuilder.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e891aaac17b933a47a9d7fa3b8e1226f
+guid: 508d38997759b4aa09840de6793578c5
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/CompilerServices/StateMachineRunner.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/CompilerServices/StateMachineRunner.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 98649642833cabf44a9dc060ce4c84a1
+guid: d59d62270c94b46cd8ca34749f09b457
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/EnumerableAsyncExtensions.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/EnumerableAsyncExtensions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ff50260d74bd54c4b92cf99895549445
+guid: ecec3e11f9abe48e4b35af55b70ce64e
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/EnumeratorAsyncExtensions.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/EnumeratorAsyncExtensions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bc661232f11e4a741af54ba1c175d5ee
+guid: a9831da34fdf64778b1dba9c78b50fda
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/ExceptionExtensions.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/ExceptionExtensions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 930800098504c0d46958ce23a0495202
+guid: 6d3c4705c8a41435f8526da8fb5e216b
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/IUniTaskSource.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/IUniTaskSource.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 3e4d023d8404ab742b5e808c98097c3c
+guid: 8c5e60190e14c4659bbe3dcc766a3f6d
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/Internal/ArrayPool.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/Internal/ArrayPool.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f83ebad81fb89fb4882331616ca6d248
+guid: 71afb4a9827e3488ca702db2bfb76ba8
 timeCreated: 1532361008
 licenseType: Free
 MonoImporter:

--- a/Assets/Plugins/UniTask/Runtime/Internal/ArrayPoolUtil.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/Internal/ArrayPoolUtil.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 424cc208fb61d4e448b08fcfa0eee25e
+guid: 366ed2704a084474cacaf7330e0a5e62
 timeCreated: 1532361007
 licenseType: Free
 MonoImporter:

--- a/Assets/Plugins/UniTask/Runtime/Internal/ArrayUtil.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/Internal/ArrayUtil.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 23146a82ec99f2542a87971c8d3d7988
+guid: 759db46f37984456d83e8a11edc491fc
 timeCreated: 1532361007
 licenseType: Free
 MonoImporter:

--- a/Assets/Plugins/UniTask/Runtime/Internal/ContinuationQueue.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/Internal/ContinuationQueue.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f66c32454e50f2546b17deadc80a4c77
+guid: 59c4295221c1c466eaf2ee00bd32142a
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/Internal/DiagnosticsExtensions.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/Internal/DiagnosticsExtensions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f80fb1c9ed4c99447be1b0a47a8d980b
+guid: 5a383124dc4674e70b332c1aece20abd
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/Internal/Error.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/Internal/Error.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5f39f495294d4604b8082202faf98554
+guid: 4dcdffe6fe5c844f591b81abc07a2b50
 timeCreated: 1532361007
 licenseType: Free
 MonoImporter:

--- a/Assets/Plugins/UniTask/Runtime/Internal/MinimumQueue.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/Internal/MinimumQueue.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7d63add489ccc99498114d79702b904d
+guid: ff1a9b462ee9c4a43b58e5d799a64f42
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/Internal/PlayerLoopRunner.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/Internal/PlayerLoopRunner.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 340c6d420bb4f484aa8683415ea92571
+guid: e1eae6125da12443d980eafdeb5b45ed
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/Internal/RuntimeHelpersAbstraction.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/Internal/RuntimeHelpersAbstraction.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 94975e4d4e0c0ea4ba787d3872ce9bb4
+guid: ede84c3c6f35f40298171dab6ccb8ff8
 timeCreated: 1532361007
 licenseType: Free
 MonoImporter:

--- a/Assets/Plugins/UniTask/Runtime/Internal/TaskTracker.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/Internal/TaskTracker.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a203c73eb4ccdbb44bddfd82d38fdda9
+guid: 8ab9ade640e3c4574a2fa26a5e01c42a
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/Internal/UnityEqualityComparer.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/Internal/UnityEqualityComparer.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ebaaf14253c9cfb47b23283218ff9b67
+guid: e8044979e4efe4c2389c52e6047197ff
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/Internal/WeakDictionary.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/Internal/WeakDictionary.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6c78563864409714593226af59bcb6f3
+guid: e8df4d0214bfc412d8e483a98d0737f9
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/PlayerLoopHelper.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/PlayerLoopHelper.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 15fb5b85042f19640b973ce651795aca
+guid: f423e3566720944be993656fca384477
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/Progress.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/Progress.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e3377e2ae934ed54fb8fd5388e2d9eb9
+guid: e6d919b3ab6a840e1a5c7c6b979b80d8
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/Triggers/AsyncAwakeTrigger.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/Triggers/AsyncAwakeTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ef2840a2586894741a0ae211b8fd669b
+guid: 5a549098b9bf54f0c9815e88d3fc44ec
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/Triggers/AsyncDestroyTrigger.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/Triggers/AsyncDestroyTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f4afdcb1cbadf954ba8b1cf465429e17
+guid: 32232f2938d3f4034842ad9f5ff28f10
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/Triggers/AsyncStartTrigger.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/Triggers/AsyncStartTrigger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b4fd0f75e54ec3d4fbcb7fc65b11646b
+guid: 69edf5051d0dc4c54b9655dc7d07c382
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/Triggers/AsyncTriggerBase.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/Triggers/AsyncTriggerBase.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2c0c2bcee832c6641b25949c412f020f
+guid: 066b16c8616b9418fb8d3c98bfe94a52
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/Triggers/AsyncTriggerExtensions.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/Triggers/AsyncTriggerExtensions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 59b61dbea1562a84fb7a38ae0a0a0f88
+guid: e5a10a4643e044f818b5934f033d310f
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/UniTask.Bridge.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/UniTask.Bridge.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bd6beac8e0ebd264e9ba246c39429c72
+guid: b09da03651b284e538c200401b22222f
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/UniTask.Delay.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/UniTask.Delay.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ecff7972251de0848b2c0fa89bbd3489
+guid: b7ad66adf0c90436f831469d2be01879
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/UniTask.Factory.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/UniTask.Factory.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4e12b66d6b9bd7845b04a594cbe386b4
+guid: e8c01e580521c4b27bd54e67cbef2e17
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/UniTask.Run.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/UniTask.Run.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8473162fc285a5f44bcca90f7da073e7
+guid: b6e23d5b65883482ab544e276093d797
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/UniTask.Threading.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/UniTask.Threading.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4132ea600454134439fa2c7eb931b5e6
+guid: 84eb2c68854db43f59e3a718e370d068
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/UniTask.WaitUntil.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/UniTask.WaitUntil.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 87c9c533491903a4288536b5ac173db8
+guid: f2588ccb875e9413bb0dec341fe9271c
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/UniTask.WhenAll.Generated.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/UniTask.WhenAll.Generated.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5110117231c8a6d4095fd0cbd3f4c142
+guid: 8bc2035c287374f5dba2c27ccd5ff94c
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/UniTask.WhenAll.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/UniTask.WhenAll.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 355997a305ba64248822eec34998a1a0
+guid: 5c43e98e1ff8046bf856a78c7a419004
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/UniTask.WhenAny.Generated.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/UniTask.WhenAny.Generated.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 13d604ac281570c4eac9962429f19ca9
+guid: d1705d712bd264bb29b024a05a129bd0
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/UniTask.WhenAny.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/UniTask.WhenAny.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c32578978c37eaf41bdd90e1b034637d
+guid: 2767192f83c544872bdf973323e9b652
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/UniTask.asmdef.meta
+++ b/Assets/Plugins/UniTask/Runtime/UniTask.asmdef.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f51ebe6a0ceec4240a699833d6309b23
+guid: a99940707aca040ae9bc611ce82bafc0
 AssemblyDefinitionImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Plugins/UniTask/Runtime/UniTask.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/UniTask.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8947adf23181ff04db73829df217ca94
+guid: 9dc2fa6a7eed94b40bbf9ab6b1c4f71c
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/UniTaskCompletionSource.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/UniTaskCompletionSource.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ed03524d09e7eb24a9fb9137198feb84
+guid: e6b62810686c24999acf2f867b0efd45
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.Shorthand.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.Shorthand.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4b4ff020f73dc6d4b8ebd4760d61fb43
+guid: 1f21967ad4d2843a7a1058415751f4b5
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/UniTaskExtensions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 05460c617dae1e440861a7438535389f
+guid: 11230d4113f7246c79f9f1da0bc87ad3
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/UniTaskObservableExtensions.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/UniTaskObservableExtensions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: eaea262a5ad393d419c15b3b2901d664
+guid: 2c16e3cc5374a4fe08d11a0a4b46c9d5
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/UniTaskScheduler.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/UniTaskScheduler.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d6cad69921702d5488d96b5ef30df1b0
+guid: e2b3c0beff79e4b3088d38e6f061d04b
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/UniTaskVoid.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/UniTaskVoid.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e9f28cd922179634d863011548f89ae7
+guid: 533da10a066ee4e4ba46518542da2ff6
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.Jobs.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.Jobs.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 30979a768fbd4b94f8694eee8a305c99
+guid: 3970c14df93454604bc435552bbdce6b
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8cc7fd65dd1433e419be4764aeb51391
+guid: 2937875ee7eb14aa6a36d0b881eaed94
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.uGUI.cs.meta
+++ b/Assets/Plugins/UniTask/Runtime/UnityAsyncExtensions.uGUI.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6804799fba2376d4099561d176101aff
+guid: 906d4fcaa023842219178ddb15581c33
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -4,15 +4,14 @@
     "com.neuecc.unirx": "https://github.com/starikcetin/UniRx.git#7.1.0",
     "com.unity.collab-proxy": "1.2.16",
     "com.unity.ext.nunit": "1.0.0",
-    "com.unity.ide.rider": "1.1.0",
-    "com.unity.ide.vscode": "1.1.3",
-    "com.unity.package-manager-ui": "2.2.0",
-    "com.unity.test-framework": "1.0.13",
+    "com.unity.ide.rider": "1.1.4",
+    "com.unity.ide.vscode": "1.2.1",
+    "com.unity.test-framework": "1.1.14",
     "com.unity.textmeshpro": "2.0.1",
-    "com.unity.timeline": "1.1.0",
+    "com.unity.timeline": "1.2.6",
     "com.unity.ugui": "1.0.0",
-    "com.unity.xr.googlevr.android": "1.18.4",
-    "com.unity.xr.googlevr.ios": "1.18.5",
+    "com.unity.xr.googlevr.android": "2.0.0",
+    "com.unity.xr.googlevr.ios": "2.0.1",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",
@@ -44,15 +43,5 @@
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
     "com.unity.modules.xr": "1.0.0"
-  },
-  "lock": {
-    "com.neuecc.unirx": {
-      "hash": "f93af89f2aafeccfc7aff9dee2cecc6d60ede06b",
-      "revision": "7.1.0"
-    },
-    "com.cysharp.unitask": {
-      "hash": "05042e5cb17806b6bd7c8565bd0afca5d2cd0c68",
-      "revision": "upm-1.2.0"
-    }
   }
 }

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,0 +1,350 @@
+{
+  "dependencies": {
+    "com.cysharp.unitask": {
+      "version": "https://github.com/twksos/UniTask.git#upm-1.2.0",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {},
+      "hash": "05042e5cb17806b6bd7c8565bd0afca5d2cd0c68"
+    },
+    "com.neuecc.unirx": {
+      "version": "https://github.com/starikcetin/UniRx.git#7.1.0",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {},
+      "hash": "f93af89f2aafeccfc7aff9dee2cecc6d60ede06b"
+    },
+    "com.unity.collab-proxy": {
+      "version": "1.2.16",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.ext.nunit": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.google.resonance.audio": {
+      "version": "2.0.0",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.ide.rider": {
+      "version": "1.1.4",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.test-framework": "1.1.1"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.ide.vscode": {
+      "version": "1.2.1",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.test-framework": {
+      "version": "1.1.14",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.ext.nunit": "1.0.0",
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.textmeshpro": {
+      "version": "2.0.1",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.ugui": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.timeline": {
+      "version": "1.2.6",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.ugui": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.ui": "1.0.0"
+      }
+    },
+    "com.unity.xr.googlevr.android": {
+      "version": "2.0.0",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.google.resonance.audio": "2.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.xr.googlevr.ios": {
+      "version": "2.0.1",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.google.resonance.audio": "2.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.modules.ai": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.androidjni": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.animation": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.assetbundle": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.audio": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.cloth": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.physics": "1.0.0"
+      }
+    },
+    "com.unity.modules.director": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.audio": "1.0.0",
+        "com.unity.modules.animation": "1.0.0"
+      }
+    },
+    "com.unity.modules.imageconversion": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.imgui": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.jsonserialize": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.particlesystem": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.physics": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.physics2d": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.screencapture": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.imageconversion": "1.0.0"
+      }
+    },
+    "com.unity.modules.subsystems": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.jsonserialize": "1.0.0"
+      }
+    },
+    "com.unity.modules.terrain": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.terrainphysics": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.physics": "1.0.0",
+        "com.unity.modules.terrain": "1.0.0"
+      }
+    },
+    "com.unity.modules.tilemap": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.physics2d": "1.0.0"
+      }
+    },
+    "com.unity.modules.ui": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.uielements": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0"
+      }
+    },
+    "com.unity.modules.umbra": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.unityanalytics": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0"
+      }
+    },
+    "com.unity.modules.unitywebrequest": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.unitywebrequestassetbundle": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.assetbundle": "1.0.0",
+        "com.unity.modules.unitywebrequest": "1.0.0"
+      }
+    },
+    "com.unity.modules.unitywebrequestaudio": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.modules.audio": "1.0.0"
+      }
+    },
+    "com.unity.modules.unitywebrequesttexture": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.modules.imageconversion": "1.0.0"
+      }
+    },
+    "com.unity.modules.unitywebrequestwww": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.modules.unitywebrequestassetbundle": "1.0.0",
+        "com.unity.modules.unitywebrequestaudio": "1.0.0",
+        "com.unity.modules.audio": "1.0.0",
+        "com.unity.modules.assetbundle": "1.0.0",
+        "com.unity.modules.imageconversion": "1.0.0"
+      }
+    },
+    "com.unity.modules.vehicles": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.physics": "1.0.0"
+      }
+    },
+    "com.unity.modules.video": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.audio": "1.0.0",
+        "com.unity.modules.ui": "1.0.0",
+        "com.unity.modules.unitywebrequest": "1.0.0"
+      }
+    },
+    "com.unity.modules.vr": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.modules.physics": "1.0.0",
+        "com.unity.modules.xr": "1.0.0"
+      }
+    },
+    "com.unity.modules.wind": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.xr": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.physics": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.modules.subsystems": "1.0.0"
+      }
+    }
+  }
+}

--- a/ProjectSettings/EditorSettings.asset
+++ b/ProjectSettings/EditorSettings.asset
@@ -3,7 +3,7 @@
 --- !u!159 &1
 EditorSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 8
+  serializedVersion: 9
   m_ExternalVersionControlSupport: Hidden Meta Files
   m_SerializationMode: 2
   m_LineEndingsForNewScripts: 2
@@ -23,4 +23,13 @@ EditorSettings:
   m_EnableTextureStreamingInEditMode: 1
   m_EnableTextureStreamingInPlayMode: 1
   m_AsyncShaderCompilation: 1
+  m_EnterPlayModeOptionsEnabled: 0
+  m_EnterPlayModeOptions: 3
   m_ShowLightmapResolutionOverlay: 1
+  m_UseLegacyProbeSampleCount: 1
+  m_AssetPipelineMode: 1
+  m_CacheServerMode: 0
+  m_CacheServerEndpoint: 
+  m_CacheServerNamespacePrefix: default
+  m_CacheServerEnableDownload: 1
+  m_CacheServerEnableUpload: 1

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.2.20f1
-m_EditorVersionWithRevision: 2019.2.20f1 (c67d00285037)
+m_EditorVersion: 2019.4.3f1
+m_EditorVersionWithRevision: 2019.4.3f1 (f880dceab6fe)


### PR DESCRIPTION
# 概要
UnityVersionを2019.4.3(LTS)にアップグレードする。

# 修正内容
* Version情報

# TODO
* [x] UniRX Pluginのmetaファイルがだいぶ変わった。

# 関連Issue
<--- Issue Link --->

# 備考