### PR TITLE
Fakeカメラを追加してEditorでのFocusをど真ん中にする

### DIFF
--- a/Assets/MyProject/Prefabs/VirtualCameraMock.prefab
+++ b/Assets/MyProject/Prefabs/VirtualCameraMock.prefab
@@ -113,6 +113,7 @@ Transform:
   m_Children:
   - {fileID: 6389071017859788214}
   - {fileID: 1466598320843669723}
+  - {fileID: 1805028467340898539}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -130,6 +131,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_camLeft: {fileID: 6389071017859788208}
   m_camRight: {fileID: 1924460603510967183}
+  m_camCenter: {fileID: 7330602069062288790}
 --- !u!1 &6389071017859788213
 GameObject:
   m_ObjectHideFlags: 0
@@ -212,4 +214,87 @@ AudioListener:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6389071017859788213}
+  m_Enabled: 1
+--- !u!1 &7294614521208569696
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1805028467340898539}
+  - component: {fileID: 7330602069062288790}
+  - component: {fileID: 6934791242868240928}
+  m_Layer: 0
+  m_Name: MainCamera_Fake
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1805028467340898539
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7294614521208569696}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6389071016953284917}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!20 &7330602069062288790
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7294614521208569696}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0.5
+    y: 0
+    width: 0.001
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 0
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!81 &6934791242868240928
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7294614521208569696}
   m_Enabled: 1

--- a/Assets/MyProject/Scripts/UI/VirtualCameraInEditor.cs
+++ b/Assets/MyProject/Scripts/UI/VirtualCameraInEditor.cs
@@ -19,14 +19,29 @@ namespace Choi.MyProj.UI.System
         [SerializeField] private Camera m_camRight;
 
         /// <summary>
+        /// Editorでのカメラ(Face For Center)
+        /// </summary>
+        [SerializeField] private Camera m_camCenter;
+
+        /// <summary>
         /// Cameraを取得
         /// </summary>
         /// <param name="isLeft"></param>
         /// <returns></returns>
-        public Camera GetCamera(bool isLeft = true)
+        public Camera GetCamera(bool isLeft)
         {
             return isLeft ? m_camLeft : m_camRight;
         }
+
+        /// <summary>
+        /// Cameraを取得
+        /// </summary>
+        /// <returns></returns>
+        public Camera GetCamera()
+        {
+            return m_camCenter;
+        }
+
         /// <summary>
         /// Rotation Speed
         /// </summary>


### PR DESCRIPTION
# 概要
Fakeカメラを追加してEditorでのFocusをど真ん中にする

# 修正内容
* Fakeカメラを追加してEditorでのFocusをど真ん中にする

# TODO
* [x] Editorで動作確認をする

# 関連Issue
<--- Issue Link --->

# 備考
* before 
<img width="802" alt="Before" src="https://user-images.githubusercontent.com/65393212/92398176-0e2b5a80-f163-11ea-8a72-bbdee3a58ca8.png">
* After
<img width="802" alt="After" src="https://user-images.githubusercontent.com/65393212/92398189-17b4c280-f163-11ea-9e02-755985cd05f6.png">

